### PR TITLE
Add public layout for common pages

### DIFF
--- a/client/src/layouts/PublicLayout.jsx
+++ b/client/src/layouts/PublicLayout.jsx
@@ -1,0 +1,15 @@
+import Header from "../components/common/Header";
+import Footer from "../components/common/Footer";
+import { Outlet } from "react-router-dom";
+
+const PublicLayout = () => {
+  return (
+    <>
+      <Header />
+      <Outlet />
+      <Footer />
+    </>
+  );
+};
+
+export default PublicLayout;

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -1,18 +1,23 @@
-import { Routes, Route } from "react-router-dom";
+import { useRoutes } from "react-router-dom";
 import MainPage from "../pages/MainPage";
 import CheckoutPage from "../components/common/CheckoutPage";
 import ThankYouPage from "../pages/ThankYouPage";
 import TermsOfService from "../components/common/TermsOfService";
+import PublicLayout from "../layouts/PublicLayout";
 
 const AppRoutes = () => {
-  return (
-    <Routes>
-      <Route path="/" element={<MainPage />} />
-      <Route path="/checkout" element={<CheckoutPage />} />
-      <Route path="/thank-you" element={<ThankYouPage />} />
-      <Route path="/terms-condition" element={<TermsOfService />} />
-    </Routes>
-  );
+  const routes = [
+    { path: "/", element: <MainPage /> },
+    {
+      element: <PublicLayout />, // Header and Footer for common pages
+      children: [
+        { path: "checkout", element: <CheckoutPage /> },
+        { path: "thank-you", element: <ThankYouPage /> },
+        { path: "terms-condition", element: <TermsOfService /> },
+      ],
+    },
+  ];
+  return useRoutes(routes);
 };
 
 export default AppRoutes;


### PR DESCRIPTION
## Summary
- revert direct Header/Footer usage
- add a PublicLayout component with Header and Footer
- wrap checkout, thank-you, and terms pages via the layout
- update routes for React Router v6

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68442c2ce0e083208fd136d260f05f6e